### PR TITLE
Update segments.py to fix namespace key not found error

### DIFF
--- a/src/powerline_k8s/segments.py
+++ b/src/powerline_k8s/segments.py
@@ -55,7 +55,7 @@ class KubernetesSegment(Segment):
         try:
             current_context = config.list_kube_config_contexts()[1]
             return current_context['name'] or SegmentContent.CTX_DEFAULT.value, \
-                current_context['context']['namespace'] or SegmentContent.NS_DEFAULT.value
+                current_context['context'].get('namespace') or SegmentContent.NS_DEFAULT.value
         except Exception as e:
             pl.error(e)
 


### PR DESCRIPTION
Had to add this change because some of our developers didn't have namespaces  defined in their kubeconfig which would throw a key not found error.